### PR TITLE
Update `/slice` skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Stay tuned. We first need to [submit][] to the offcial marketplace.
 
 ### Planning
 
-| Command  | Description                                                                                                                                                                                                                                                                                                                     |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/slice` | Breaks an epic into independently shippable vertical slices — each delivering real user value end-to-end. Works Socratically: guides you to find the slices yourself, validates each against the "can it ship independently?" and "can a user see the value?" tests, then helps you sequence by risk and learning, not by ease. |
+| Command  | Description                                                                                                                                                                                                                                                                                                                                                                                        |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/slice` | Turns a feature into well-defined, independently shippable slices — whether it's an epic that needs breaking apart or a single story that needs sharpening into a job story. Works Socratically: guides you to find the slices yourself, validates each against the "can it ship independently?" and "can a user see the value?" tests, then helps you sequence by risk and learning, not by ease. |
 
 ### Learning
 

--- a/skills/slice/SKILL.md
+++ b/skills/slice/SKILL.md
@@ -1,43 +1,62 @@
 ---
 name: slice
-description: Break an epic into vertical slices — independently shippable pieces of work that each deliver real user value end-to-end
-argument-hint: "[epic description]"
+description: Turn a feature into well-defined, independently shippable slices — whether it's an epic that needs breaking apart or a single story that needs sharpening into a job story
+argument-hint: "[feature description]"
 disable-model-invocation: true
 ---
 
-## Phase 1: Understand the Epic
+## Phase 1: Understand the Work
 
-If no epic is specified, open with:
+If no feature is specified, open with:
 
-**"What's the epic? Describe the feature or capability you want to break into slices."**
+**"What are you building? Describe the feature or capability — big or small."**
 
 Wait for their answer before proceeding.
 
-Once the epic is known, ask three things — conversationally, not as a form:
+Once the feature is known, ask three things — conversationally, not as a form:
 
-**"Before we break this down, I need to understand it. Three things:**
+**"Before we slice this, I need to understand it. Three things:**
 
-**Who is this for — specifically? Not 'users', but which user, in which moment, with which need.**
+**Who is this for — specifically? Not 'users', but which person, in which moment, with which need.**
 
-**What does the finished epic look like? If it shipped completely, what can that user do that they can't do today?**
+**What does done look like? When this ships, what can that person do that they can't do today?**
 
 **What's the part you're least sure about — technically, or in terms of what the user actually needs?"**
 
-Wait for their answers. Listen for: vagueness about the user (a sign the scope isn't understood), vagueness about done (a sign it will expand), and what they flag as uncertain (that's where the risk lives, and where the first slice should probably go).
+Wait for their answers. Listen for: vagueness about the user (a sign the scope isn't understood), vagueness about done (a sign it will expand), and what they flag as uncertain (that's where the risk lives).
 
-If their answers are vague, ask one follow-up before moving on. Do not proceed to slicing on an epic you don't understand.
+If their answers are vague, ask one follow-up before moving on. Do not proceed to slicing on work you don't understand.
 
 ---
 
-## Phase 2: Find the Slices — Socratically
+## Phase 2: Shape the Slices — Socratically
 
-Do not produce a slice list. Guide them to find the slices themselves, one question at a time.
+Based on the size and complexity of the feature, take one of two paths. Do not announce which path you're taking — just follow the one that fits.
+
+### Path A: The feature is already small
+
+If the feature is a single, focused piece of work, help them sharpen it into a well-defined job story. Read `~/.claude/skills/slice/examples/job-stories.md` for the job story format. Guide them with:
+
+- "What's the specific situation the user is in when they need this? Not just 'using the app' — what moment triggers the need?"
+- "What do they want to do in that moment — and why does it matter to them?"
+- "How would you know this is done? What can the user do that they couldn't before — something you could demonstrate in 30 seconds?"
+
+Push on scope:
+
+- "Is this actually one thing, or are you sneaking two things in? Could any part of this ship on its own?"
+- "Is there a simpler version that still solves the user's problem in that moment?"
+
+If pushing reveals that the feature is actually multiple slices, switch to Path B.
+
+### Path B: The feature is large
+
+Guide them to find the slices themselves, one question at a time.
 
 Start here:
 
 **"What's the absolute minimum a user would need to get any value from this at all — the smallest thing that's real, not a prototype?"**
 
-This is the walking skeleton (thoughtbot / XP). It's almost always smaller than they think. Push on it:
+This is the walking skeleton (thoughtbot / XP). It's almost always smaller than they think. Read `~/.claude/skills/slice/examples/full-stack-slices.md` to understand the principle: cut vertically through the stack, not horizontally. Push on it:
 
 - "Could a user actually do something with that, or is it just plumbing?"
 - "Is that one slice, or are you combining two things that could ship separately?"
@@ -46,7 +65,7 @@ This is the walking skeleton (thoughtbot / XP). It's almost always smaller than 
 Once the first slice is clear, work outward:
 
 - "What's the next most important thing — not the next most obvious thing to build, but the next most valuable to the user?"
-- "What's the riskiest assumption in this epic — the thing that, if you're wrong, changes everything? Should that be a slice?"
+- "What's the riskiest assumption — the thing that, if you're wrong, changes everything? Should that be a slice?"
 - "Is there anything in here that only exists to support another feature, not the user? That's probably not a slice."
 - "Which slices depend on each other, and which are actually independent?"
 
@@ -59,25 +78,44 @@ If a slice fails either test, it's either too big or it's not a slice.
 
 ---
 
-## Phase 3: Sequence and Deliverable
+## Phase 3: Deliverable
 
-Once the slices are identified, guide the sequencing:
+### For a single slice
+
+Produce a job story. Read `~/.claude/skills/slice/examples/job-stories.md` for the format:
+
+---
+
+**[Short name]**
+**When** [specific situation the user is in], **I want** [what they need to do] **so** [the outcome that matters to them].
+**Ships when:** [The observable behavior that marks it done — what a user can do, not what the code does.]
+**Risk / learning:** [What this slice tests or de-risks, or "Low risk" if straightforward.]
+
+---
+
+Close with:
+
+**"Is this actually the smallest thing that delivers real value — or did you sneak scope into it?"**
+
+### For multiple slices
+
+Guide the sequencing:
 
 **"Now order them. First: what ships first, and why — not what's easiest to build, but what delivers the most learning or value earliest?"**
 
 Ask:
 
-- "Which slice would tell you the most about whether this epic is heading in the right direction?"
+- "Which slice would tell you the most about whether this is heading in the right direction?"
 - "Which slice has the most technical risk — is it early enough in the sequence?"
-- "If the client ran out of budget after two slices, which two would you want to have shipped?"
+- "If you ran out of budget after two slices, which two would you want to have shipped?"
 
-When sequencing is agreed, produce the deliverable. Read `~/.claude/skills/slice/example.md` for a complete example of the expected format and quality. Format each slice consistently:
+When sequencing is agreed, produce the deliverable. Read `~/.claude/skills/slice/example.md` for a complete example of the expected format and quality. Format each slice as a job story:
 
 ---
 
 **Slice [N]: [Short name]**
-**As a** [specific user], **I want** [capability] **so that** [value delivered].
-**Ships when:** [The observable behaviour that marks it done — what a user can do, not what the code does.]
+**When** [specific situation the user is in], **I want** [what they need to do] **so** [the outcome that matters to them].
+**Ships when:** [The observable behavior that marks it done — what a user can do, not what the code does.]
 **Depends on:** [Any prior slice it requires, or "none".]
 **Risk / learning:** [What this slice tests or de-risks.]
 

--- a/skills/slice/examples/full-stack-slices.md
+++ b/skills/slice/examples/full-stack-slices.md
@@ -1,0 +1,136 @@
+# Break apart your features into full-stack slices
+
+I often see people split work into horizontal slices. Ticket A: database tables
+and models. Ticket B: controllers. Ticket C: front-end.
+
+There's something better &mdash; split the work into full-stack slices.
+
+## The full-stack slice
+
+Think of your feature like a stack of pancakes, where each pancake represents a
+layer of your system. Eat a piece of all pancakes at the same time. Don't eat
+them one at a time.
+
+![Two images. Left has three pancakes on a plate with an arrow cutting through all three. Right image has three separate pancakes flat on the plate with red X across them.](https://images.thoughtbot.com/blog-vellum-image-uploads/kPlHvn2ASAexM5od3NIY_pancakes-stack-flat.png)
+
+That may seem unrealistic. After all, there's usually logic that is shared by
+every part of the feature.
+
+Sometimes features are more like icebergs, where a small change in one layer
+corresponds to a large change in a separate layer. For example, the UI may have
+a smaller footprint than the back-end. That's okay. Handle more of the back-end
+in a ticket, but cut vertically through the iceberg. Don't cut horizontally.
+
+![Two images. Left has iceberg with a green line cutting vertically through it. It takes a little off the top but a lot off the bottom. Right image is an iceberg with a horizontal crack through it. A red X is overlaid.](https://images.thoughtbot.com/blog-vellum-image-uploads/dYj0u4mWRYWFt870ZjV3_icerberg-vertical-horizontal.png)
+
+## Why it's better
+
+- Work iteratively. In the [post agile] world, everybody pretends to work in
+  iterations. But can we ship at the end of our iteration? If we build the
+  database and tables in one iteration, our customers don't receive any new
+  work. But if we ship a sliver of the full stack, they get something.
+
+- Discover the glue code. When working in front-end and back-end slices, we
+  often overlook the code that ties the two slices together. And that spells
+  trouble at the eleventh hour &mdash; an incorrect abstraction or a missed
+  parameter, and we're having to order pizza for dinner and work into the night.
+  But if we build a full-stack slice, we need the glue code while building the
+  slice. No surprises Friday night.
+
+- Learn quickly. When working with full-stack slices, we may find a large
+  roadblock that forces our project in a new direction. Or we may ship a portion
+  of our feature and receive customer feedback that changes our roadmap.
+
+- Stay nimble. We know one thing about the future: it will bring change.
+  External forces change the highest priority project today into a low priority
+  project tomorrow. If we only work on one layer of our system and priorities
+  change, our customers will not get any part of the feature. But if we ship
+  full-stack slices, we can change projects at the drop of a hat with minimal
+  loss.
+
+- Only write the code you need. When working on the back-end in isolation from
+  the final product, we work with incomplete information &mdash; guessing what
+  the front-end will need. So, we over-engineer solutions that take longer to
+  develop and create unused code paths that we must then maintain.
+
+[post agile]: https://pragdave.me/blog/2014/03/04/time-to-kill-agile.html
+
+## An example
+
+Let's look at an example from a recent project.
+
+I was assigned three tickets that considered the front-end and back-end as two
+completely different aspects of the application:
+
+![Front-end and back-end split completely as two different tablets. Front-end has UI. Back-end has some plumbing and a database.](https://images.thoughtbot.com/blog-vellum-image-uploads/aMCVIrOTaGjOih1PO28O_split-into-frontend-backend.png)
+
+- Ticket X: build the back-end &mdash; controllers, models, all the
+  functionality needed for rendering, filtering, and searching.
+
+- Ticket Y: build the front end &mdash; navigation, UI cards, a sidebar for
+  filtering, and a navbar for search and a create button.
+
+- Ticket Z: build a sliding panel of the UI that reused a lot of back-end work.
+
+Tickets X and Y were completely separated into front-end and back-end. The
+complexity of each was high, meaning I could spend a lot of time building things
+I assumed the other ticket would need.
+
+Ticket Z was separate from the other two, and it was mostly front-end work since
+it used existing back-end functionality.
+
+### Looking from the perspective of the user
+
+Instead of following those tickets, I looked at the UI from the perspective of
+the user to find pieces that could be shipped separately. That gave me four
+major sections with some subsections: A.1, A.2, B, C.1, C.3, and D.
+
+![The UI broken down into four sections: A, B, C, D. A is the UI card itself. B is a sidebar on the left of the main section. C is the action buttons on the top right nav. D is a transparent sliding panel.](https://images.thoughtbot.com/blog-vellum-image-uploads/MVs5PFeTRVa78lTMqlmA_split-into-full-stack-sections.png)
+
+- **A.1**: Display the list of items. This was the first slice of the iceberg,
+  so I included a lot of the shared logic: navigation (a user has to get to the
+  page), the UI cards with essential information, and all the back-end work
+  needed to render them.
+
+- **A.2**: Each card in the list had some complex interactive elements. I
+  separated those into a new ticket. It mostly included UI work and small
+  back-end pieces.
+
+- **B**: Filtering in the sidebar so that users could narrow down the cards they
+  see. This was blocked by A.1.
+
+- **C.1**: Adding search that would filter the cards to the ones matching the
+  query. Much like B, this one needed the core of A.1.
+
+- **C.2**: Creating a new item. Most of the back-end logic for this already
+  existed. So this was a trivial UI addition.
+
+- **D**: Adding the sliding panel. In a new application, I would have made the
+  sliding panel its own feature made of full-stack slices. Thankfully, most of
+  the back-end was already built. So this was primarily UI work.
+
+You can decide where to put the first slice of the iceberg that has shared
+logic. I put it in A.1 because it seemed like the most important part of the
+feature. Without it, users would not get any value from the rest.
+
+Some of the other work &mdash; like B, C.1, and C.2 &mdash; became thin slivers
+of full-stack work. And that made for concise pull requests. Avoid the
+temptation to group those thin slivers with something else. I have seen many
+"simple" ancillary tasks unearth complex issues and delay the release of the
+core feature.
+
+## Full stack depends on your stack
+
+You may think these lessons don't apply to you because you build APIs or
+single-page applications. But it does. Full-stack is whatever your fullest stack
+can be.
+
+If you build APIs, the consumers of the API are your users. And they will
+benefit from an endpoint that returns a list of items even before you allow them
+to search or filter those items.
+
+Likewise, if you build single-page applications, splitting your front-end work
+into discrete portions that you can deliver separately will bring value to your
+users faster while keeping you nimble.
+
+**Break apart your features into full-stack slices** whatever your stack.

--- a/skills/slice/examples/job-stories.md
+++ b/skills/slice/examples/job-stories.md
@@ -1,0 +1,20 @@
+# Job stories
+
+Job stories use the format: **When** [situation], **I want** [motivation], **So**
+[expected outcome].
+
+Unlike user stories ("As a [role], I want..."), job stories anchor on the
+_context that triggers the need_ rather than a persona. This makes them
+especially useful for slicing because each story describes a distinct moment
+worth shipping for.
+
+## Examples
+
+**When** I'm buying a baseball card, **I want** to know if it is fairly priced,
+**So** I can have confidence in my purchase.
+
+**When** I'm viewing an event, **I want** to know which comedians are
+performing, **So** I can decide if the event is worth attending.
+
+**When** I've paid my energy bill, **I want** to see how much it was and how
+much I saved, **So** I can understand my energy spending.


### PR DESCRIPTION
Update skill to account for features big or small, and no longer assume
we're working with an epic.

Additionally, we add [full-stack slices][slices] and [job
story][job-story] examples.

[slices]: https://thoughtbot.com/blog/break-apart-your-features-into-full-stack-slices
[job-story]: https://thoughtbot.com/playbook/rapid-product-validation/jtbd#how-to-write-and-use-job-stories
