### PR TITLE
Add acceptance criteria to `/slice`

### DIFF
--- a/skills/slice/SKILL.md
+++ b/skills/slice/SKILL.md
@@ -46,6 +46,11 @@ Push on scope:
 - "Is this actually one thing, or are you sneaking two things in? Could any part of this ship on its own?"
 - "Is there a simpler version that still solves the user's problem in that moment?"
 
+Push on acceptance criteria:
+
+- "How would you verify this actually works? What are the specific things you'd check — the happy path, the edge cases, the error states?"
+- "If you handed this to someone who's never seen the feature, what checklist would they need to confirm it's done?"
+
 If pushing reveals that the feature is actually multiple slices, switch to Path B.
 
 ### Path B: The feature is large
@@ -69,6 +74,11 @@ Once the first slice is clear, work outward:
 - "Is there anything in here that only exists to support another feature, not the user? That's probably not a slice."
 - "Which slices depend on each other, and which are actually independent?"
 
+As each slice takes shape, push on acceptance criteria:
+
+- "How would you verify this slice works? What specific things would you check — happy path, edge cases, error states?"
+- "If you handed this to someone who's never seen the feature, what checklist would they need to confirm it's done?"
+
 Keep pushing until they've named the full set. Validate each slice against two tests — ask them:
 
 1. "Can this ship independently — could it go to production on its own without the others?"
@@ -89,7 +99,12 @@ Produce a job story. Read `~/.claude/skills/slice/examples/job-stories.md` for t
 **[Short name]**
 **When** [specific situation the user is in], **I want** [what they need to do] **so** [the outcome that matters to them].
 **Ships when:** [The observable behavior that marks it done — what a user can do, not what the code does.]
-**Risk / learning:** [What this slice tests or de-risks, or "Low risk" if straightforward.]
+**Acceptance criteria:**
+
+- [ ] [Specific, verifiable condition — the happy path]
+- [ ] [Edge case or boundary condition]
+- [ ] [Error state or failure handling, if applicable]
+      **Risk / learning:** [What this slice tests or de-risks, or "Low risk" if straightforward.]
 
 ---
 
@@ -116,8 +131,13 @@ When sequencing is agreed, produce the deliverable. Read `~/.claude/skills/slice
 **Slice [N]: [Short name]**
 **When** [specific situation the user is in], **I want** [what they need to do] **so** [the outcome that matters to them].
 **Ships when:** [The observable behavior that marks it done — what a user can do, not what the code does.]
-**Depends on:** [Any prior slice it requires, or "none".]
-**Risk / learning:** [What this slice tests or de-risks.]
+**Acceptance criteria:**
+
+- [ ] [Specific, verifiable condition — the happy path]
+- [ ] [Edge case or boundary condition]
+- [ ] [Error state or failure handling, if applicable]
+      **Depends on:** [Any prior slice it requires, or "none".]
+      **Risk / learning:** [What this slice tests or de-risks.]
 
 ---
 

--- a/skills/slice/example.md
+++ b/skills/slice/example.md
@@ -3,31 +3,66 @@
 **Slice 1: Subscribe to a plan**
 **As a** new customer on the pricing page, **I want** to choose a plan and enter payment details **so that** I have an active subscription.
 **Ships when:** A user can select a plan, enter a credit card, and see a confirmation page showing their active subscription.
-**Depends on:** None.
-**Risk / learning:** Validates the Stripe integration works end-to-end. If this is painful, every subsequent slice will be too — surface it first.
+**Acceptance criteria:**
+
+- [ ] User can see available plans with names, prices, and billing frequency
+- [ ] User can enter credit card details via Stripe checkout
+- [ ] Successful payment creates an active subscription record
+- [ ] User sees a confirmation page with plan name and next billing date
+- [ ] Declined card shows a clear error message without creating a subscription
+      **Depends on:** None.
+      **Risk / learning:** Validates the Stripe integration works end-to-end. If this is painful, every subsequent slice will be too — surface it first.
 
 **Slice 2: View current subscription**
 **As a** subscribed customer, **I want** to see my current plan, billing date, and payment method **so that** I know what I'm paying and when.
 **Ships when:** A logged-in subscriber sees a billing page showing plan name, next billing date, and last 4 digits of their card.
-**Depends on:** Slice 1.
-**Risk / learning:** Forces the data model to be right — if the subscription record doesn't store what we need, we find out here.
+**Acceptance criteria:**
+
+- [ ] Billing page is accessible from account navigation
+- [ ] Page displays current plan name and price
+- [ ] Page displays next billing date
+- [ ] Page displays last 4 digits of card on file
+- [ ] Non-subscribed users see a prompt to subscribe instead of billing details
+      **Depends on:** Slice 1.
+      **Risk / learning:** Forces the data model to be right — if the subscription record doesn't store what we need, we find out here.
 
 **Slice 3: Cancel subscription**
 **As a** subscribed customer, **I want** to cancel my subscription **so that** I stop being charged.
 **Ships when:** A subscriber can click "cancel", sees a confirmation, and their subscription is marked as cancelling (active until end of billing period). No more charges after the period ends.
-**Depends on:** Slice 2 (needs the billing page to put the cancel button on).
-**Risk / learning:** Tests the Stripe cancellation webhook flow — does our system correctly handle the async state change?
+**Acceptance criteria:**
+
+- [ ] Cancel button is visible on the billing page for active subscribers
+- [ ] Clicking cancel shows a confirmation dialog before proceeding
+- [ ] After confirming, subscription status changes to "cancelling"
+- [ ] User retains access until the end of the current billing period
+- [ ] Stripe cancellation webhook updates the local subscription record when the period ends
+- [ ] Cancelled users see a prompt to resubscribe on the billing page
+      **Depends on:** Slice 2 (needs the billing page to put the cancel button on).
+      **Risk / learning:** Tests the Stripe cancellation webhook flow — does our system correctly handle the async state change?
 
 **Slice 4: Change plan**
 **As a** subscribed customer, **I want** to upgrade or downgrade my plan **so that** I get the features I need without overpaying.
 **Ships when:** A subscriber can switch between plans, sees the prorated cost, and the change takes effect immediately.
-**Depends on:** Slice 2.
-**Risk / learning:** Proration logic is the most complex billing calculation. Deferring this until Stripe basics are proven.
+**Acceptance criteria:**
+
+- [ ] User can see other available plans from the billing page
+- [ ] Switching plans shows the prorated cost before confirming
+- [ ] Plan change takes effect immediately after confirmation
+- [ ] User's next billing amount reflects the new plan
+- [ ] Attempting to switch to the current plan is a no-op (button disabled or hidden)
+      **Depends on:** Slice 2.
+      **Risk / learning:** Proration logic is the most complex billing calculation. Deferring this until Stripe basics are proven.
 
 **Slice 5: Update payment method**
 **As a** subscribed customer, **I want** to update my credit card **so that** my subscription doesn't lapse when my card expires.
 **Ships when:** A subscriber can enter a new card on the billing page and see it reflected as their active payment method.
-**Depends on:** Slice 2.
-**Risk / learning:** Low risk — straightforward Stripe API call. Sequenced last because it's high value but low uncertainty.
+**Acceptance criteria:**
+
+- [ ] Update payment button is visible on the billing page
+- [ ] User can enter new card details via Stripe checkout
+- [ ] Successful update shows the new card's last 4 digits on the billing page
+- [ ] Failed card update shows an error and retains the previous payment method
+      **Depends on:** Slice 2.
+      **Risk / learning:** Low risk — straightforward Stripe API call. Sequenced last because it's high value but low uncertainty.
 
 **Sequencing rationale:** Slice 1 proves the Stripe integration works. Slice 2 builds the billing page that every subsequent slice needs as a home. Slices 3–5 are independent of each other and ordered by risk: cancellation tests webhooks, plan changes test proration, payment update is a known quantity. If the client runs out of budget after slice 3, subscribers can sign up, see their billing, and cancel — a complete if minimal subscription experience.


### PR DESCRIPTION
Improve skill by having it help the caller determine acceptance
criteria. That way, it can be passed to the `/test-driven-development`
skill more effectively.
