### PR TITLE
Simplify release script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,14 +49,13 @@ and a rewording can meaningfully change behavior. Here's how we apply semver:
 - **MINOR** — add a new skill or meaningfully update an existing one.
 - **PATCH** — fix typos, update descriptions, or make trivial adjustments.
 
-To cut a release, use the included binstub:
+Bump the version in `.claude-plugin/plugin.json` as part of your pull request.
+Once the PR is merged, cut a release with the included binstub:
 
-    bin/release           # interactive — prompts for the new version
-    bin/release 2.0.0     # non-interactive
+    bin/release
 
-This updates the version in `.claude-plugin/plugin.json`, commits the change,
-and creates an annotated git tag. It does not push — you'll be shown the push
-command so you can inspect before publishing.
+This reads the version from `plugin.json`, creates an annotated git tag, and
+pushes it.
 
 See [obra/superpowers] for a reference example of how a mature Claude Code plugin
 handles versioning, release notes, and git tags.

--- a/bin/release
+++ b/bin/release
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
-# Release script for the rails-consultant Claude Code plugin.
+# Tag and push a release based on the version in .claude-plugin/plugin.json.
 # Modeled after the binstub that ships with Ruby gems (bundle gem).
 #
 # Usage:
-#   bin/release           # interactive — prompts for the new version
-#   bin/release 2.1.0     # non-interactive — uses the given version
+#   bin/release
+#
+# The version in plugin.json should already be bumped via a pull request.
+# This script reads that version, creates an annotated git tag, and pushes it.
 
 set -euo pipefail
 
@@ -21,72 +23,17 @@ if ! command -v jq &> /dev/null; then
   exit 1
 fi
 
-current_version=$(jq -r '.version' "$plugin_json")
-echo "Current version: $current_version"
-
-if [ $# -ge 1 ]; then
-  new_version="$1"
-else
-  printf "New version: "
-  read -r new_version
-fi
-
-if [ -z "$new_version" ]; then
-  echo "Error: version cannot be blank." >&2
-  exit 1
-fi
-
-if [ "$new_version" = "$current_version" ]; then
-  echo "Error: new version is the same as the current version." >&2
-  exit 1
-fi
-
-if ! echo "$new_version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-  echo "Error: version must follow semver (e.g. 1.2.3)." >&2
-  exit 1
-fi
-
-branch=$(git rev-parse --abbrev-ref HEAD)
-
-if [ "$branch" != "main" ]; then
-  echo "Error: releases must be cut from main (currently on $branch)." >&2
-  exit 1
-fi
-
-if ! git diff --quiet || ! git diff --cached --quiet; then
-  echo "Error: there are uncommitted changes. Commit or stash them first." >&2
-  exit 1
-fi
-
-tag="v$new_version"
+version=$(jq -r '.version' "$plugin_json")
+tag="v$version"
 
 if git tag -l "$tag" | grep -q .; then
   echo "Error: tag $tag already exists." >&2
   exit 1
 fi
 
-echo ""
-echo "Releasing $current_version -> $new_version"
-echo ""
+echo "Tagging $tag and pushing..."
 
-if [ $# -eq 0 ]; then
-  printf "Continue? [y/N] "
-  read -r confirm
-  if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
-    echo "Aborted." >&2
-    exit 1
-  fi
-fi
-
-jq --arg v "$new_version" '.version = $v' "$plugin_json" > "$plugin_json.tmp" \
-  && mv "$plugin_json.tmp" "$plugin_json"
-
-git add "$plugin_json"
-git commit -m "Release $tag"
 git tag -a "$tag" -m "Release $tag"
+git push origin "$tag"
 
-echo ""
-echo "Tagged $tag. Push with:"
-echo ""
-echo "  git push origin $branch --follow-tags"
-echo ""
+echo "Released $tag."


### PR DESCRIPTION
The previous script was overloaded. Specifically, it was required to be
run on `main`, but since that's a protected branch, it wouldn't be
possible to update the value in `plugin.json`.

Instead, this script is basically a wrapper for the git tag API, and
just ensures a tag is created for the version set in `plugin.json`.
