### PR TITLE
Note socratic-review subagent assessment in NEWS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+- Fan out subagents for the `socratic-review` skill's silent assessment: large or
+  unfamiliar targets (multi-file PRs, SHAs, inherited code) are now explored by
+  parallel subagents — one per problem space — whose findings are merged into the
+  private ranked list, while small targets are still read inline.
+
 - Strengthen the `test-driven-development` skill's outside-in workflow: run the
   affected test after every change and let the failure dictate the next move, and
   write a new failing test at each layer you drop into (e.g. a request spec before


### PR DESCRIPTION
Follow-up to #32 — adds the missing NEWS.md entry for the `socratic-review` Step 0 subagent fan-out change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)