### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rails-consultant",
   "description": "A collection of skills for Rails development and consulting, with an emphasis on learning, communication, and client success",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "thoughtbot"
   },

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [1.1.0] - 2026-06-12
+
 - Fan out subagents for the `socratic-review` skill's silent assessment: large or
   unfamiliar targets (multi-file PRs, SHAs, inherited code) are now explored by
   parallel subagents — one per problem space — whose findings are merged into the


### PR DESCRIPTION
Bumps `.claude-plugin/plugin.json` from `1.0.0` to `1.1.0` and rolls the `NEWS.md` `[Unreleased]` entries into a dated `1.1.0` release.

## Why MINOR

Per the semver rules in `CONTRIBUTING.md`, a meaningful update to an existing skill is a MINOR bump. Two such updates have landed since `1.0.0`:

- `socratic-review` — Step 0 now fans out parallel subagents for large/unfamiliar targets (#32)
- `test-driven-development` — strengthened outside-in workflow (#31)

## Release

Once this merges, the tag is cut with `bin/release` (reads the version from `plugin.json`, creates an annotated `v1.1.0` tag, pushes it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)