### PR TITLE
Sync marketplace.json version to 1.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "A collection of skills for Rails development and consulting, with an emphasis on learning, communication, and client success",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "plugins": [
     {
@@ -15,7 +15,7 @@
         "repo": "thoughtbot/rails-consultant"
       },
       "description": "A collection of skills for Rails development and consulting, with an emphasis on learning, communication, and client success",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "category": "workflows",
       "keywords": ["rails", "ruby", "consulting", "tdd", "code-review"]
     }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,10 @@ and a rewording can meaningfully change behavior. Here's how we apply semver:
 - **MINOR** — add a new skill or meaningfully update an existing one.
 - **PATCH** — fix typos, update descriptions, or make trivial adjustments.
 
-Bump the version in `.claude-plugin/plugin.json` as part of your pull request.
-Once the PR is merged, cut a release with the included binstub:
+Bump the version in `.claude-plugin/plugin.json` as part of your pull request,
+and keep `.claude-plugin/marketplace.json` in sync — it carries the same version
+in both its `metadata.version` and its `plugins[].version` fields. Once the PR is
+merged, cut a release with the included binstub:
 
     bin/release
 


### PR DESCRIPTION
The version bump in #34 only updated `plugin.json`, leaving `.claude-plugin/marketplace.json` stale at `1.0.0` in both its `metadata.version` and `plugins[].version` fields. This syncs it to `1.1.0`.

Also updates `CONTRIBUTING.md` so the version-bump step explicitly covers keeping `marketplace.json` in sync — `marketplace.json` was introduced (#28) after the release docs were written, which is how the gap slipped through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)