### PR TITLE
Add skills.sh badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Rails Consultant
 
+[![skills.sh](https://skills.sh/b/thoughtbot/rails-consultant)](https://skills.sh/thoughtbot/rails-consultant)
+
 A collection of [skills][] for Rails development and consulting, with an
 emphasis on learning, communication, and client success.
 


### PR DESCRIPTION
Adds a [skills.sh](https://skills.sh) badge to the top of the README, linking to the marketplace page for this plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)