### PR TITLE
Document installation via skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ emphasis on learning, communication, and client success.
 
 ## Installation
 
+### Via skills
+
+Install with [skills][]:
+
+```
+npx skills add thoughtbot/rails-consultant
+```
+
+### Via Claude Code
+
 Add the marketplace to Claude Code:
 
 ```


### PR DESCRIPTION
Adds instructions for installing Rails Consultant with [skills](https://code.claude.com/docs/en/skills) via `npx skills add`, alongside the existing Claude Code marketplace flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)