### PR TITLE
Bump version to 1.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "A collection of skills for Rails development and consulting, with an emphasis on learning, communication, and client success",
-    "version": "1.3.0"
+    "version": "1.3.1"
   },
   "plugins": [
     {
@@ -15,7 +15,7 @@
         "repo": "thoughtbot/rails-consultant"
       },
       "description": "A collection of skills for Rails development and consulting, with an emphasis on learning, communication, and client success",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "category": "workflows",
       "keywords": ["rails", "ruby", "consulting", "tdd", "code-review"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rails-consultant",
   "description": "A collection of skills for Rails development and consulting, with an emphasis on learning, communication, and client success",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": {
     "name": "thoughtbot"
   },

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [1.3.1] - 2026-07-18
+
 - Fix `/feature-dev` erroring at the slicing phase: it invoked `slice` and
   `test-driven-development` through the Skill tool, but both are user-invoke-only
   (`disable-model-invocation`) and the tool rejects them. Those phases now follow


### PR DESCRIPTION
Release the `/feature-dev` fix from #45.

- Bump `version` to `1.3.1` in `.claude-plugin/plugin.json` and both version fields in `.claude-plugin/marketplace.json`.
- Graduate the NEWS entry from `[Unreleased]` to a dated `[1.3.1]` heading.

PATCH bump per `CONTRIBUTING.md`: this fixes broken behavior in an existing skill without adding or restructuring anything. Once merged, `bin/release` will tag `v1.3.1` and a GitHub release will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)