### PR TITLE
Ground `slice` in the codebase before slicing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "A collection of skills for Rails development and consulting, with an emphasis on learning, communication, and client success",
-    "version": "1.4.0"
+    "version": "1.5.0"
   },
   "plugins": [
     {
@@ -15,7 +15,7 @@
         "repo": "thoughtbot/rails-consultant"
       },
       "description": "A collection of skills for Rails development and consulting, with an emphasis on learning, communication, and client success",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "category": "workflows",
       "keywords": ["rails", "ruby", "consulting", "tdd", "code-review"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rails-consultant",
   "description": "A collection of skills for Rails development and consulting, with an emphasis on learning, communication, and client success",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": {
     "name": "thoughtbot"
   },

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 ## [Unreleased]
 
+## [1.5.0] - 2026-07-30
+
+- Ground `/slice` in the codebase before it starts slicing. Phase 1 now ends with
+  an optional step that fans out subagents to find whether the feature already
+  exists, what's reusable, and how comparable features are tested — the last of
+  which is what turns vague acceptance criteria into concrete ones. The findings
+  are there to sharpen the Socratic questions, not to answer them, and the step
+  stands down for greenfield work or when the conversation already carries a
+  codebase map.
+- Rework `/feature-dev`'s handoff into slicing now that `/slice` grounds itself.
+  Phase 2 is that grounding, so Phase 3 explicitly skips `/slice`'s version of it
+  rather than paying for the same exploration twice, and uses it as a checklist
+  instead: if Phase 2 missed what already exists or what the real edge cases are,
+  fill the gap before writing acceptance criteria.
+
 ## [1.4.0] - 2026-07-29
 
 - Make `/socratic-review`'s Step 0 assessment concrete about how it fans out. It

--- a/skills/feature-dev/SKILL.md
+++ b/skills/feature-dev/SKILL.md
@@ -40,7 +40,7 @@ Then make an explicit call on size. Ask yourself (and the user, if it's genuinel
 
 This matters most in a mature Rails app: the right slice and the right tests depend on where similar features live, what the testing conventions are, and which abstractions already exist. Skipping this leads to slices that ignore reality and code that fights the grain of the app.
 
-Match the effort to the feature. For a small, well-understood change, a few targeted reads inline are enough — don't spin up subagents to rediscover something you can see in one file. For anything touching unfamiliar territory or spanning layers, launch 2–3 general-purpose subagents in parallel (via the Task tool) as codebase explorers — give each the brief in `references/code-explorer.md` plus a different angle to cover:
+Match the effort to the feature. For a small, well-understood change, a few targeted reads inline are enough — don't spin up subagents to rediscover something you can see in one file. For anything touching unfamiliar territory or spanning layers, launch 2–3 general-purpose subagents in parallel (via the `Agent` tool) as codebase explorers — give each the brief in `references/code-explorer.md` plus a different angle to cover:
 
 - Find features similar to this one and trace their implementation end to end.
 - Map the architecture and conventions for the area this slice touches (models, controllers, jobs, views, wherever it lands).
@@ -48,7 +48,9 @@ Match the effort to the feature. For a small, well-understood change, a few targ
 
 Ask each explorer to return the 5–10 files most worth reading. When they return, **read those files yourself** before proceeding — the subagents build the map, but you need the detail in context to slice and test well.
 
-Close the phase with a short summary of the patterns and conventions that will shape the slice: where the code will live, what it should look like, what to reuse.
+Close the phase with a short summary of the patterns and conventions that will shape the slice: where the code will live, what it should look like, what to reuse. Include what already exists — if part of the feature is half-built or an adjacent feature covers some of it, that changes the slice, and Phase 3 needs to know before it starts asking questions.
+
+**This phase is the grounding that `slice` would otherwise do for itself.** Its Phase 1 has a codebase-grounding step that fans out the same way, and it is written to stand down when the conversation already carries a map. Carry this summary into Phase 3 so that happens — see the note there.
 
 ---
 
@@ -57,6 +59,8 @@ Close the phase with a short summary of the patterns and conventions that will s
 **Goal:** turn the framed feature into one sharp, well-defined slice with real acceptance criteria.
 
 **Run the `slice` skill's process** and let it run the conversation. `slice` is user-invoke-only (`disable-model-invocation: true`), so you can't call it through the Skill tool — read its `SKILL.md` (see the path note below) and drive its process yourself. Because Phase 1 already established this is a single slice, `slice` should sharpen it into one job story (its Path A) rather than break an epic apart. Feed it what you learned in Phases 1–2 so the conversation starts warm instead of from zero.
+
+**Skip `slice`'s codebase-grounding step — Phase 2 already did it.** Its Phase 1 ends with a grounding step that fans out subagents to find what already exists, what's reusable, and how comparable features are tested. That is exactly Phase 2's job here, and the step tells you to stand down when the conversation already carries a map. Hand it Phase 2's summary and the files you read, and go straight to shaping the slice. Running it again would spend real tokens rediscovering what you already know — but do use it as a checklist: if Phase 2 didn't surface what already exists or what the real edge cases in this area are, fill that gap now, because Phase 3's acceptance criteria depend on both.
 
 What you need out of this phase is the deliverable `slice` produces: a job story with a clear **"ships when"** and a concrete list of **acceptance criteria** — happy path, edge cases, and error states. Those acceptance criteria are not paperwork; they become the failing tests in Phase 4. Push (or let `slice` push) until each criterion is specific and verifiable — "a user can X and sees Y" — because a vague criterion produces a vague test that proves nothing.
 
@@ -155,7 +159,7 @@ Feed it the slice's "ships when" line as context so the commit message explains 
 
 The pieces this workflow orchestrates are each rigorous on their own; your job is to run them in sequence and keep the handoffs clean, not to water them down.
 
-- `slice` is Socratic — it leads the user to define the work through questions. Let it. Don't pre-answer for them.
+- `slice` is Socratic — it leads the user to define the work through questions. Let it. Don't pre-answer for them. Arriving from Phase 2 makes this harder, not easier: you know things the user hasn't been told, and the pull is to skip the questions and present the slice. Use what you know to make the questions specific instead.
 - `test-driven-development` is strict about order. Don't let the momentum of a clear slice tempt you into writing code before the test.
 - The built-in `/code-review --fix` does the reviewing and fixing; your responsibility after it runs is to make sure the suite is still green and that any behavior it changed is covered by a test. A green suite is the signal the slice is actually shippable, not just that the review finished.
 - `git-commit` makes the atomic-commit call itself. Because a slice is one coherent change, expect a single commit — don't pre-split the work for it, but do hand it the "ships when" context so the message explains the why.

--- a/skills/slice/SKILL.md
+++ b/skills/slice/SKILL.md
@@ -27,6 +27,25 @@ Wait for their answers. Listen for: vagueness about the user (a sign the scope i
 
 If their answers are vague, ask one follow-up before moving on. Do not proceed to slicing on work you don't understand.
 
+### Ground it in the codebase — when there is one
+
+Slices invented in the abstract ignore reality. In an existing app, the right cut depends on what's already there: half of it may exist already, the layers it touches may already have the abstractions it needs, and the edge cases worth putting in acceptance criteria are the ones this domain actually has, not the ones you can imagine.
+
+Skip this step entirely when it doesn't apply:
+
+- **The conversation already carries a codebase map.** If you arrived here from `/feature-dev`, its Phase 2 has already done this work — use what it found and move on. Never explore the same ground twice.
+- **There's nothing to explore.** Greenfield work, a brand-new app, or a feature that touches no existing behavior. Same for a product-shaped conversation where no repo is in play.
+
+Otherwise, match the effort to the feature. For a small change in familiar territory, a few targeted reads inline are enough. For anything spanning layers or touching code you don't know, launch 2–3 general-purpose subagents in parallel (via the `Agent` tool) — give each the brief in `references/slice-explorer.md` plus a different angle to cover:
+
+- Find out whether this already exists, in whole or in part — the feature itself, an earlier attempt, or adjacent behavior that covers some of it.
+- Map the layers and models this would touch, and what abstractions are already available to reuse.
+- Find the closest comparable feature and report how it's tested — including the specific edge cases and error states those tests cover.
+
+Ask each subagent to return the files most worth reading. When they return, read those files yourself before opening Phase 2.
+
+**What you do with this matters more than finding it.** These facts are here to sharpen your questions, not to answer them. You now know things the developer may not, and the temptation is to hand it over as a plan — don't. Keep asking; let the grounding make the questions specific. "There's already a `Subscription#cancel` that soft-deletes — does your slice extend that or replace it?" is the same Socratic move as before, just aimed somewhere real. Do not present findings as a report, do not propose the slices yourself, and do not slide into designing the implementation. The developer still does the seeing.
+
 ---
 
 ## Phase 2: Shape the Slices — Socratically

--- a/skills/slice/references/slice-explorer.md
+++ b/skills/slice/references/slice-explorer.md
@@ -1,0 +1,30 @@
+# Slice Explorer Brief
+
+The brief for the Phase 1 grounding subagents. Hand this to each general-purpose subagent along with the one angle it should cover.
+
+## Mission
+
+Find out what this app already has, so the slicing conversation is grounded in the real codebase instead of an imagined one. You are gathering facts, not proposing a plan — read, trace, and report.
+
+Your report feeds a Socratic conversation in which the developer defines the slices themselves. That makes what you leave out as important as what you include: no slice proposals, no draft acceptance criteria, no design recommendations. Report what exists; the orchestrator decides which questions it raises.
+
+## What to trace
+
+**Whether this already exists.** The most useful thing you can find is that some or all of the work is already done. Look for the feature itself, an earlier attempt, adjacent behavior that covers part of it, dead or unreachable code, feature flags, and abandoned migrations. Half-built is a finding; so is "nothing like this exists anywhere."
+
+**What it would touch, and what's reusable.** Identify the models, tables, controllers, jobs, and views in the area, and the abstractions already available (service objects, query objects, form objects, concerns, policies). Note what a new slice could lean on rather than rebuild.
+
+**How comparable features are tested — and what those tests actually check.** Find the closest existing feature and read its tests. Report the framework and structure, but go further: list the specific edge cases and error states those tests cover. Nullable columns, existing validations, the states a record can be in, what happens when an external call fails. This is the part that turns vague acceptance criteria into concrete ones.
+
+## What to report
+
+Keep it tight and factual:
+
+- **What already exists** — with `file:line`, and how complete it is.
+- **What it would touch** — the models, tables, and layers in play.
+- **What's reusable** — existing abstractions and helpers, with `file:line`.
+- **Real edge cases and failure modes in this area** — drawn from the code and its tests, not invented.
+- **How comparable features are tested** — framework, structure, factories, and what those tests cover.
+- **The files most worth reading** — the handful the orchestrator needs in context to ask sharp questions.
+
+Return findings only. Do not contact the user, do not write any code, and do not suggest how the work should be sliced — the orchestrator reads your report and the key files, then runs the conversation.


### PR DESCRIPTION
Relates to #30 

Slicing an existing app from an imagined version of it produces slices that don't survive contact with the code. Half the feature may already be built, or the layers it touches may already have the abstractions it needs.

Phase 1 now ends with a grounding step that fans out subagents to ask whether the feature already exists, what it would touch, and how the closest comparable feature is tested. That last one does the most work. Reading the existing tests is how you find out which columns are nullable and what happens when an external call fails, and that's the difference between a criterion that produces a real test and one that produces a vague one.

The risk is that grounding turns a Socratic skill into a briefing. The subagents are told not to propose slices, and the skill is told the facts exist to make its questions specific rather than to answer them.

## Why feature-dev changes too

Its Phase 2 already does this exploration, so Phase 3 skips slice's version instead of paying for it twice. It keeps it as a checklist, though: Phase 2 asks about conventions and testing patterns, so it can miss what already exists or what the real edge cases are. This also fixes a stale reference in that phase, where the Task tool is now called Agent.

MINOR per CONTRIBUTING. Issue #50 covers a separate pre-existing bug in slice's example file paths, which this PR doesn't touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
