### PR TITLE
Fix `slice`'s example paths for plugin installs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "A collection of skills for Rails development and consulting, with an emphasis on learning, communication, and client success",
-    "version": "1.5.0"
+    "version": "1.5.1"
   },
   "plugins": [
     {
@@ -15,7 +15,7 @@
         "repo": "thoughtbot/rails-consultant"
       },
       "description": "A collection of skills for Rails development and consulting, with an emphasis on learning, communication, and client success",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "category": "workflows",
       "keywords": ["rails", "ruby", "consulting", "tdd", "code-review"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rails-consultant",
   "description": "A collection of skills for Rails development and consulting, with an emphasis on learning, communication, and client success",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "thoughtbot"
   },

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+## [1.5.1] - 2026-07-30
+
+- Fix `/slice` silently losing its examples in a plugin install. Four reads in
+  `skills/slice/SKILL.md` pointed at `~/.claude/skills/slice/…`, which only
+  exists if you installed the skills standalone; under the plugin the files sit
+  in the plugin cache, so the reads failed and the skill carried on without the
+  job story format or the full-stack slicing examples. The paths are now
+  relative to the skill directory, which resolves in both installs.
+
 ## [1.5.0] - 2026-07-30
 
 - Ground `/slice` in the codebase before it starts slicing. Phase 1 now ends with

--- a/skills/slice/SKILL.md
+++ b/skills/slice/SKILL.md
@@ -54,7 +54,7 @@ Based on the size and complexity of the feature, take one of two paths. Do not a
 
 ### Path A: The feature is already small
 
-If the feature is a single, focused piece of work, help them sharpen it into a well-defined job story. Read `~/.claude/skills/slice/examples/job-stories.md` for the job story format. Guide them with:
+If the feature is a single, focused piece of work, help them sharpen it into a well-defined job story. Read `examples/job-stories.md` for the job story format. Guide them with:
 
 - "What's the specific situation the user is in when they need this? Not just 'using the app' — what moment triggers the need?"
 - "What do they want to do in that moment — and why does it matter to them?"
@@ -80,7 +80,7 @@ Start here:
 
 **"What's the absolute minimum a user would need to get any value from this at all — the smallest thing that's real, not a prototype?"**
 
-This is the walking skeleton (thoughtbot / XP). It's almost always smaller than they think. Read `~/.claude/skills/slice/examples/full-stack-slices.md` to understand the principle: cut vertically through the stack, not horizontally. Push on it:
+This is the walking skeleton (thoughtbot / XP). It's almost always smaller than they think. Read `examples/full-stack-slices.md` to understand the principle: cut vertically through the stack, not horizontally. Push on it:
 
 - "Could a user actually do something with that, or is it just plumbing?"
 - "Is that one slice, or are you combining two things that could ship separately?"
@@ -111,7 +111,7 @@ If a slice fails either test, it's either too big or it's not a slice.
 
 ### For a single slice
 
-Produce a job story. Read `~/.claude/skills/slice/examples/job-stories.md` for the format:
+Produce a job story. Read `examples/job-stories.md` for the format:
 
 ---
 
@@ -143,7 +143,7 @@ Ask:
 - "Which slice has the most technical risk — is it early enough in the sequence?"
 - "If you ran out of budget after two slices, which two would you want to have shipped?"
 
-When sequencing is agreed, produce the deliverable. Read `~/.claude/skills/slice/example.md` for a complete example of the expected format and quality. Format each slice as a job story:
+When sequencing is agreed, produce the deliverable. Read `example.md` for a complete example of the expected format and quality. Format each slice as a job story:
 
 ---
 


### PR DESCRIPTION
Closes #50.

`skills/slice/SKILL.md` read its bundled examples through `~/.claude/skills/slice/…` in four places:

- `examples/job-stories.md` (Path A, and again in the Phase 3 deliverable)
- `examples/full-stack-slices.md`
- `example.md`

That path only exists in a standalone skills install. Under the plugin the files sit in the plugin cache, so each read failed, and it failed quietly: nothing stops the phase when a read comes back empty. The skill just carried on without the job story format or the slicing examples.

These now use paths relative to the skill directory, which resolve in either install.

I checked the other skills for the same pattern. `feature-dev`, `socratic-review`, `test-driven-development`, and `explain` already reference their bundled files relatively. The one remaining `~/.claude` mention is `skills/feature-dev/SKILL.md:169`, which is prose about where a `SKILL.md` lives in each install layout rather than a path it reads, so it stays.

Patch bump to 1.5.1 in `plugin.json` and `marketplace.json`, plus a `NEWS.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)